### PR TITLE
fix: add editor-specific space keybinding and explicit vim.leader default

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "onStartupFinished"
   ],
   "doomInstallDefaults": {
+    "vim.leader": "<space>",
     "vim.normalModeKeyBindingsNonRecursive": [
       {
         "before": [
@@ -1607,22 +1608,27 @@
       {
         "key": "space",
         "command": "whichkey.show",
+        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !whichkeyActive && !inDebugRepl && !suggestWidgetVisible && !parameterHintsVisible"
+      },
+      {
+        "key": "space",
+        "command": "whichkey.show",
         "when": "focusedView == '' && !whichkeyActive && !inputFocus && (!auxiliaryBarVisible || view.workbench.panel.chat.view.copilot.visible)"
       },
       {
         "key": "space",
         "command": "whichkey.show",
-        "when": "sideBarFocus && !inputFocus && !whichkeyActive || view.workbench.panel.markers.view.visible && !inputFocus"
+        "when": "(sideBarFocus && !inputFocus && !whichkeyActive) || (view.workbench.panel.markers.view.visible && !inputFocus)"
       },
       {
         "key": "alt+space",
         "command": "whichkey.show",
-        "when": "inDebugRepl || terminalFocus|| view.workbench.panel.markers.view.visible && inputFocus || vim.mode == 'insert'"
+        "when": "inDebugRepl || terminalFocus || (view.workbench.panel.markers.view.visible && inputFocus) || vim.mode == 'Insert'"
       },
       {
         "key": "ctrl+space",
         "command": "whichkey.show",
-        "when": "inDebugRepl || terminalFocus || view.workbench.panel.markers.view.visible && inputFocus || vim.mode == 'insert'"
+        "when": "inDebugRepl || terminalFocus || (view.workbench.panel.markers.view.visible && inputFocus) || vim.mode == 'Insert'"
       },
       {
         "key": "t",


### PR DESCRIPTION
## Summary

- **Problem:** The extension's contributed space keybinding only fired under `!inputFocus`, which excludes the main editor. In the editor, Space only worked as leader if VSCodeVim happened to intercept it first; when it didn't, VS Code handled Space normally and caused scroll behavior instead of opening the whichkey menu.
- **Fix:** Added an editor-specific `space -> whichkey.show` binding with condition `editorTextFocus && vim.active && vim.mode != 'Insert'` so the leader key works reliably in the editor.
- Added explicit `vim.leader: "<space>"` to `doomInstallDefaults` so the leader mapping is installed deterministically rather than relying on user config.
- Fixed `when` clause operator precedence by adding parentheses to compound conditions in sidebar/panel bindings.
- Fixed incorrect lowercase `vim.mode == 'insert'` to `vim.mode == 'Insert'` in alt+space and ctrl+space fallback bindings.

## Test plan

- [x] `npm run compile` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] `npm run pretest` passes
- [x] Open editor in normal mode, press Space — whichkey menu opens (no scroll)
- [x] In insert mode, Space types a space character normally
- [x] Alt+Space and Ctrl+Space still open whichkey in terminal/debug REPL
- [x] Sidebar focus: Space opens whichkey menu